### PR TITLE
Set up for default environment

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -26,7 +26,7 @@ return [
 	|
 	*/
 
-	'default' => env('DB_DEFAULT', 'mysql'),
+	'default' => env('DB_DEFAULT', 'sqlite'),
 
 	/*
 	|--------------------------------------------------------------------------

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@
 ### Setup
 
 - Clone repo
+- Create your .env file from the example file: `cp .env.testng .env`
 - Install composer dependencies: `composer install`
 - Create databases by creating the following files:
     - `storage/database.sqlite`


### PR DESCRIPTION
Set the default database to sqlite.

Include an instruction in the readme to suggest people copy the testing environment to default.