### PR TITLE
Add Vagrant via Homestead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /tags
 .env
 .idea
+.vagrant
 composer.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "homestead"]
+	path = homestead
+	url = https://github.com/laravel/homestead.git

--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -1,0 +1,31 @@
+---
+ip: "192.168.10.10"
+memory: 2048
+cpus: 1
+hostname: code
+name: code
+provider: virtualbox
+
+folders:
+    - map: "."
+      to: "/home/vagrant/code"
+
+sites:
+    - map: homestead.app
+      to: "/home/vagrant/code/public"
+
+databases:
+    - homestead
+
+# blackfire:
+#     - id: foo
+#       token: bar
+#       client-id: foo
+#       client-token: bar
+
+# ports:
+#     - send: 50000
+#       to: 5000
+#     - send: 7777
+#       to: 777
+#       protocol: udp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@ require 'json'
 require 'yaml'
 
 VAGRANTFILE_API_VERSION ||= "2"
+confDir = $confDir ||= File.expand_path("./homestead", File.dirname(__FILE__))
 
 homesteadYamlPath = "Homestead.yaml"
 homesteadJsonPath = "Homestead.json"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,27 @@
+require 'json'
+require 'yaml'
+
+VAGRANTFILE_API_VERSION ||= "2"
+
+homesteadYamlPath = "Homestead.yaml"
+homesteadJsonPath = "Homestead.json"
+afterScriptPath = "after.sh"
+aliasesPath = "aliases"
+
+require File.expand_path(confDir + '/scripts/homestead.rb')
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    if File.exists? aliasesPath then
+        config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
+    end
+
+    if File.exists? homesteadYamlPath then
+        Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))
+    elsif File.exists? homesteadJsonPath then
+        Homestead.configure(config, JSON.parse(File.read(homesteadJsonPath)))
+    end
+
+    if File.exists? afterScriptPath then
+        config.vm.provision "shell", path: afterScriptPath
+    end
+end

--- a/after.sh
+++ b/after.sh
@@ -5,7 +5,7 @@ set -e
 cd code
 
 sudo -u vagrant -H bash -c "cp .env.testing .env; \
-  composer install; \
+  composer install -n --prefer-dist; \
   if [ ! -f ~/.key_generated ]; then php artisan key:generate; touch ~/.key_generated; fi; \
   touch storage/database.sqlite; \
   touch storage/testing.sqlite; \

--- a/after.sh
+++ b/after.sh
@@ -5,8 +5,8 @@ set -e
 cd code
 
 sudo -u vagrant -H bash -c "cp .env.testing .env; \
-  if [ ! -f ~/.key_generated ]; then php artisan key:generate; touch ~/.key_generated; fi; \
   composer install; \
+  if [ ! -f ~/.key_generated ]; then php artisan key:generate; touch ~/.key_generated; fi; \
   touch storage/database.sqlite; \
   touch storage/testing.sqlite; \
   php artisan migrate; \

--- a/after.sh
+++ b/after.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+cd code
+
+sudo -u vagrant -H bash -c "cp .env.testing .env; \
+  if [ ! -f ~/.key_generated ]; then php artisan key:generate; touch ~/.key_generated; fi; \
+  composer install; \
+  touch storage/database.sqlite; \
+  touch storage/testing.sqlite; \
+  php artisan migrate; \
+  php artisan migrate --database=sqlite_testing;"

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@ You can setup this sample manually or use [Vagrant](https://www.vagrantup.com/) 
 
 #### Vagrant
 - Clone repo
+- Cd into the cloned directory
+- Run vagrant up
 
 To SSH into the machine to run your tests, run ```vagrant ssh```. You can access the app on the guest vm under http://192.168.10.10/.
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,9 @@
 
 ### Setup
 
+You can setup this sample manually or use [Vagrant](https://www.vagrantup.com/) to automatically set up a development environment for you.
+
+#### Manual
 - Clone repo
 - Create your .env file from the example file: `cp .env.testing .env`
 - Install composer dependencies: `composer install`
@@ -15,6 +18,11 @@
     - `php artisan migrate --database=sqlite_testing`
 - Server: run `php -S localhost:8000 -t public`
 - Browse to localhost:8000/posts
+
+#### Vagrant
+- Clone repo
+
+To SSH into the machine to run your tests, run ```vagrant ssh```. You can access the app on the guest vm under http://192.168.10.10/.
 
 ### To test
 


### PR DESCRIPTION
This allows an extremely quick way to get started with the project, one simply runs vagrant up and after a minute the site can be accessed under http://http://192.168.10.10/. Using vagrant ssh one can launch  into the created VM and execute the build/test commands for codeception. With vagrant destroy it is then destroyed. Incredibly nice for cool samples like this which you sometimes want to test quickly, adapt into existing code then throw out again.

Very useful for playing around with this without any kind of setup required.
