### PR TITLE
Use Codeception 2.2 in builds instead of dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require-dev": {
     "phpunit/phpunit": "~4.0",
     "phpspec/phpspec": "~2.1",
-    "codeception/codeception": "dev-master",
+    "codeception/codeception": "2.2.*",
     "symfony/dom-crawler": "~3.0",
     "symfony/css-selector": "~3.0"
   },


### PR DESCRIPTION
Because codeception-laravel5-sample is breaking all builds for Codeception 2.2
